### PR TITLE
Change metainfo feature list to unordered

### DIFF
--- a/data/io.github.lo2dev.Echo.metainfo.xml.in
+++ b/data/io.github.lo2dev.Echo.metainfo.xml.in
@@ -14,9 +14,9 @@
   <description>
     <p>Utility to ping websites.</p>
     <p>Features include:</p>
-    <ol>
+    <ul>
       <li>Advanced ping parameters like ping count, timeout, etc</li>
-    </ol>
+    </ul>
   </description>
 
   <launchable type="desktop-id">io.github.lo2dev.Echo.desktop</launchable>


### PR DESCRIPTION
It's not normal to have feature lists numbered. Also makes it look less weird given that it only has one point :smile: 